### PR TITLE
fix: ping width extends into names or scoreboard

### DIFF
--- a/src/main/java/io/toadlabs/numeralping/mixin/PlayerListHudMixin.java
+++ b/src/main/java/io/toadlabs/numeralping/mixin/PlayerListHudMixin.java
@@ -1,5 +1,8 @@
 package io.toadlabs.numeralping.mixin;
 
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import com.llamalad7.mixinextras.sugar.Local;
 import org.spongepowered.asm.mixin.*;
 import org.spongepowered.asm.mixin.injection.*;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
@@ -11,8 +14,26 @@ import net.minecraft.client.gui.DrawContext;
 import net.minecraft.client.gui.hud.PlayerListHud;
 import net.minecraft.client.network.PlayerListEntry;
 
+import java.util.List;
+
 @Mixin(PlayerListHud.class)
 public class PlayerListHudMixin {
+
+	@WrapOperation(method = "render", at = @At(value = "INVOKE", target = "Ljava/lang/Math;min(II)I", ordinal = 0))
+	private int adjustTablistEntryWidth(int a, int b, Operation<Integer> original, @Local(ordinal = 0) List<PlayerListEntry> playerListEntries) {
+		NumeralConfig config = NumeralConfig.instance();
+		int vanillaPingWidth = 9;
+		int maxPingWidth = vanillaPingWidth;
+
+		for (PlayerListEntry playerListEntry : playerListEntries) {
+			String pingString = Integer.toString(playerListEntry.getLatency());
+			pingString = config.shiftPing(pingString);
+
+			maxPingWidth = Math.max(maxPingWidth, client.textRenderer.getWidth(pingString));
+		}
+
+		return a + maxPingWidth - vanillaPingWidth;
+	}
 
 	@Inject(method = "renderLatencyIcon", at = @At("HEAD"), cancellable = true)
 	public void renderDetailedLatency(DrawContext context, int width, int x, int y, PlayerListEntry entry,

--- a/src/main/java/io/toadlabs/numeralping/mixin/PlayerListHudMixin.java
+++ b/src/main/java/io/toadlabs/numeralping/mixin/PlayerListHudMixin.java
@@ -32,7 +32,7 @@ public class PlayerListHudMixin {
 			maxPingWidth = Math.max(maxPingWidth, client.textRenderer.getWidth(pingString));
 		}
 
-		return a + maxPingWidth - vanillaPingWidth;
+		return original.call(a + maxPingWidth - vanillaPingWidth, b);
 	}
 
 	@Inject(method = "renderLatencyIcon", at = @At("HEAD"), cancellable = true)


### PR DESCRIPTION
fixes #4

The added mixin adjusts what minecraft thinks is the 

Before:
![02_10-12-42_java9ca](https://github.com/user-attachments/assets/16ef704f-15ce-4012-a97b-767c18fc3d51)

After:
![02_10-11-50_java2af](https://github.com/user-attachments/assets/3c26510b-5e49-4acb-9817-fb6cf047521f)

Also fixes scoreboard values
![image](https://github.com/user-attachments/assets/c184d9be-2568-4fa9-8dc5-163ebfeb6df6)
