### PR TITLE
feat: allow custom ping string format

### DIFF
--- a/src/main/java/io/toadlabs/numeralping/config/NumeralConfig.java
+++ b/src/main/java/io/toadlabs/numeralping/config/NumeralConfig.java
@@ -28,6 +28,8 @@ public final class NumeralConfig {
 			levelTwoPingThreshold = 600,
 			levelThreePingThreshold = 1000;
 
+	public String pingFormat = "%p";
+
 	public static NumeralConfig instance() {
 		return NumeralPingMod.instance().getConfig();
 	}
@@ -43,24 +45,6 @@ public final class NumeralConfig {
 		try (Writer writer = new OutputStreamWriter(Files.newOutputStream(file), StandardCharsets.UTF_8)) {
 			GSON.toJson(this, writer);
 		}
-	}
-
-	public String shiftPing(String string) {
-		if (smallPing) {
-			// based on numeric ping
-			char[] characters = new char[string.length()];
-
-			for (int index = 0; index < string.length(); index++) {
-				characters[index] = string.charAt(index);
-
-				if (characters[index] >= '0' && characters[index] <= '9')
-					characters[index] += 8272;
-			}
-
-			return String.valueOf(characters);
-		}
-
-		return string;
 	}
 
 }

--- a/src/main/java/io/toadlabs/numeralping/integration/ModMenuIntegration.java
+++ b/src/main/java/io/toadlabs/numeralping/integration/ModMenuIntegration.java
@@ -63,8 +63,8 @@ public final class ModMenuIntegration implements ModMenuApi {
 
 							// Ping Format
 							.option(Option.<String>createBuilder()
-								.name(Text.translatable(OPTION + ".pingFormat"))
-								.description(OptionDescription.of(Text.translatable(OPTION + ".pingFormat.desc")))
+								.name(Component.translatable(OPTION + ".pingFormat"))
+								.description(OptionDescription.of(Component.translatable(OPTION + ".pingFormat.desc")))
 								.binding(NumeralConfig.DEFAULTS.pingFormat,
 									() -> config.pingFormat,
 									value -> config.pingFormat = value)

--- a/src/main/java/io/toadlabs/numeralping/integration/ModMenuIntegration.java
+++ b/src/main/java/io/toadlabs/numeralping/integration/ModMenuIntegration.java
@@ -8,6 +8,7 @@ import dev.isxander.yacl3.api.OptionDescription;
 import dev.isxander.yacl3.api.YetAnotherConfigLib;
 import dev.isxander.yacl3.api.controller.ColorControllerBuilder;
 import dev.isxander.yacl3.api.controller.IntegerFieldControllerBuilder;
+import dev.isxander.yacl3.api.controller.StringControllerBuilder;
 import dev.isxander.yacl3.api.controller.TickBoxControllerBuilder;
 import io.toadlabs.numeralping.NumeralPingMod;
 import io.toadlabs.numeralping.config.NumeralConfig;
@@ -60,6 +61,16 @@ public final class ModMenuIntegration implements ModMenuApi {
 											value -> config.smallPing = value)
 									.controller(TickBoxControllerBuilder::create)
 									.build())
+
+							// Ping Format
+							.option(Option.<String>createBuilder()
+								.name(Text.translatable(OPTION + ".pingFormat"))
+								.description(OptionDescription.of(Text.translatable(OPTION + ".pingFormat.desc")))
+								.binding(NumeralConfig.DEFAULTS.pingFormat,
+									() -> config.pingFormat,
+									value -> config.pingFormat = value)
+								.controller(StringControllerBuilder::create)
+								.build())
 
 							// Ping Thresholds
 

--- a/src/main/java/io/toadlabs/numeralping/mixin/PlayerListHudMixin.java
+++ b/src/main/java/io/toadlabs/numeralping/mixin/PlayerListHudMixin.java
@@ -26,8 +26,7 @@ public class PlayerListHudMixin {
 		int maxPingWidth = vanillaPingWidth;
 
 		for (PlayerListEntry playerListEntry : playerListEntries) {
-			String pingString = Integer.toString(playerListEntry.getLatency());
-			pingString = config.shiftPing(pingString);
+			String pingString = Utils.getPingText(playerListEntry.getLatency());
 
 			maxPingWidth = Math.max(maxPingWidth, client.textRenderer.getWidth(pingString));
 		}

--- a/src/main/java/io/toadlabs/numeralping/mixin/PlayerListHudMixin.java
+++ b/src/main/java/io/toadlabs/numeralping/mixin/PlayerListHudMixin.java
@@ -22,8 +22,7 @@ public class PlayerListHudMixin {
 		if (config.playerList) {
 			callback.cancel();
 
-			String pingString = Integer.toString(entry.getLatency());
-			pingString = config.shiftPing(pingString);
+			String pingString = Utils.getPingText(entry.getLatency());
 
 			context.getMatrices().pushMatrix();
 

--- a/src/main/java/io/toadlabs/numeralping/mixin/PlayerListHudMixin.java
+++ b/src/main/java/io/toadlabs/numeralping/mixin/PlayerListHudMixin.java
@@ -24,7 +24,7 @@ public class PlayerListHudMixin {
 		int vanillaPingWidth = 9;
 		int maxPingWidth = vanillaPingWidth;
 
-		for (PlayerListEntry playerListEntry : playerListEntries) {
+		for (PlayerInfo playerListEntry : playerListEntries) {
 			String pingString = Utils.getPingText(playerListEntry.getLatency());
 
 			maxPingWidth = Math.max(maxPingWidth, minecraft.font.width(pingString));

--- a/src/main/java/io/toadlabs/numeralping/mixin/ServerEntryMixin.java
+++ b/src/main/java/io/toadlabs/numeralping/mixin/ServerEntryMixin.java
@@ -29,7 +29,7 @@ public class ServerEntryMixin {
 		NumeralConfig config = NumeralConfig.instance();
 
 		if (config.serverList) {
-			args.set(2, ((int) args.get(2)) + 10 - client.textRenderer.getWidth(Utils.getPingText(server.ping)));
+			args.set(2, ((int) args.get(2)) + 10 - minecraft.font.width(Utils.getPingText(serverData.ping)));
 		}
 	}
 
@@ -48,8 +48,8 @@ public class ServerEntryMixin {
 	public void renderDetailedLatency(GuiGraphics instance, RenderPipeline pipeline, ResourceLocation sprite, int x, int y, int width, int height) {
 		NumeralConfig config = NumeralConfig.instance();
 
-		if (server.ping >= 0 && config.serverList) {
-			String text = Utils.getPingText(server.ping);
+		if (serverData.ping >= 0 && config.serverList) {
+			String text = Utils.getPingText(serverData.ping);
 
 			if (config.smallPing) {
 				y--;

--- a/src/main/java/io/toadlabs/numeralping/mixin/ServerEntryMixin.java
+++ b/src/main/java/io/toadlabs/numeralping/mixin/ServerEntryMixin.java
@@ -14,7 +14,6 @@ import net.minecraft.util.Identifier;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
-import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.ModifyArgs;
 import org.spongepowered.asm.mixin.injection.Redirect;
@@ -30,7 +29,7 @@ public class ServerEntryMixin {
 		NumeralConfig config = NumeralConfig.instance();
 
 		if (config.serverList) {
-			args.set(2, ((int) args.get(2)) + 10 - client.textRenderer.getWidth(getPingText(config, server.ping)));
+			args.set(2, ((int) args.get(2)) + 10 - client.textRenderer.getWidth(Utils.getPingText(server.ping)));
 		}
 	}
 
@@ -50,7 +49,7 @@ public class ServerEntryMixin {
 		NumeralConfig config = NumeralConfig.instance();
 
 		if (server.ping >= 0 && config.serverList) {
-			String text = getPingText(config, server.ping);
+			String text = Utils.getPingText(server.ping);
 
 			if (config.smallPing) {
 				y--;
@@ -64,11 +63,6 @@ public class ServerEntryMixin {
 		}
 
 		instance.drawGuiTexture(pipeline, sprite, x, y, width, height);
-	}
-
-	@Unique
-	private String getPingText(NumeralConfig config, long ping) {
-		return config.shiftPing(Long.toString(ping));
 	}
 
 	@Shadow

--- a/src/main/java/io/toadlabs/numeralping/util/Utils.java
+++ b/src/main/java/io/toadlabs/numeralping/util/Utils.java
@@ -29,4 +29,33 @@ public final class Utils {
 		return colour.getRGB();
 	}
 
+	public static String getPingText(long latency) {
+		NumeralConfig config = NumeralConfig.instance();
+
+		String pingString = config.pingFormat.replace("%p", String.valueOf(latency));
+		pingString = shiftPing(pingString);
+
+		return pingString;
+	}
+
+	private static String shiftPing(String string) {
+		NumeralConfig config = NumeralConfig.instance();
+
+		if (config.smallPing) {
+			// based on numeric ping
+			char[] characters = new char[string.length()];
+
+			for (int index = 0; index < string.length(); index++) {
+				characters[index] = string.charAt(index);
+
+				if (characters[index] >= '0' && characters[index] <= '9')
+					characters[index] += 8272;
+			}
+
+			return String.valueOf(characters);
+		}
+
+		return string;
+	}
+
 }

--- a/src/main/resources/assets/numeralping/lang/de_de.json
+++ b/src/main/resources/assets/numeralping/lang/de_de.json
@@ -5,6 +5,8 @@
    "numeralping.option.serverList.desc": "Zahlen-Ping in der Serverliste aktivieren.",
    "numeralping.option.smallPing": "Kleiner Ping",
    "numeralping.option.smallPing.desc": "Ping-Text mit alternativen Unicode-Zeichen verkleinern.",
+   "numeralping.option.pingFormat": "Ping Format",
+   "numeralping.option.pingFormat.desc": "Eigenes Format für den angezeigten Ping.\n\n%p kann als Platzhalter für den numerischen Ping verwendet werden.",
    "numeralping.option.defaultPingThreshold": "Standard Grenzwert",
    "numeralping.option.defaultPingThreshold.desc": "Höchster Ping-Wert für die Standardfarbe.",
    "numeralping.option.levelOnePingThreshold": "Grenzwert der Stufe Eins",

--- a/src/main/resources/assets/numeralping/lang/en_gb.json
+++ b/src/main/resources/assets/numeralping/lang/en_gb.json
@@ -5,6 +5,8 @@
   "numeralping.option.serverList.desc": "Enable numeral ping in the server list.",
   "numeralping.option.smallPing": "Small Ping",
   "numeralping.option.smallPing.desc": "Shrink the ping text using alternative Unicode characters.",
+  "numeralping.option.pingFormat": "Ping Format",
+  "numeralping.option.pingFormat.desc": "Define a custom format for the displayed ping.\n\nUse %p as a placeholder for the numeric ping.",
   "numeralping.option.defaultPingThreshold": "Default Threshold",
   "numeralping.option.defaultPingThreshold.desc": "Highest ping value for the default colour.",
   "numeralping.option.levelOnePingThreshold": "Level One Threshold",

--- a/src/main/resources/assets/numeralping/lang/en_us.json
+++ b/src/main/resources/assets/numeralping/lang/en_us.json
@@ -5,6 +5,8 @@
   "numeralping.option.serverList.desc": "Enable numeral ping in the server list.",
   "numeralping.option.smallPing": "Small Ping",
   "numeralping.option.smallPing.desc": "Shrink the ping text using alternative Unicode characters.",
+  "numeralping.option.pingFormat": "Ping Format",
+  "numeralping.option.pingFormat.desc": "Define a custom format for the displayed ping.\n\nUse %p as a placeholder for the numeric ping.",
   "numeralping.option.defaultPingThreshold": "Default Threshold",
   "numeralping.option.defaultPingThreshold.desc": "Highest ping value for the default color.",
   "numeralping.option.levelOnePingThreshold": "Level One Threshold",


### PR DESCRIPTION
This allows for custom formats like "%pms" which would be displayed as "10ms" for a ping of 10 milliseconds.
- added a static Utils.getPingText method to get the ping text of a given latency
- moved `shiftPing` from the NumeralConfig to the Utils class
- added yacl config options for configuring the format of the ping string. The placeholder %p can be used to reference the numeric ping value

As is the custom format would most likely intersect with player names, which looks bad. #25 would fix this issue. This PR is marked as a draft until #25 is merged, as the tablist width logic needs adjusting to match the new ping format of this PR.